### PR TITLE
TokenDbCache was always creating new entries rather than modifying th…

### DIFF
--- a/WebApp-RoleClaims-DotNet/Utils/TokenDbCache.cs
+++ b/WebApp-RoleClaims-DotNet/Utils/TokenDbCache.cs
@@ -79,14 +79,17 @@ namespace WebApp_RoleClaims_DotNet.Utils
             // if state changed
             if (this.HasStateChanged)
             {
-                Cache = new TokenCacheEntry
+                if (Cache == null)
                 {
-                    userObjId = userObjId,
-                    cacheBits = this.Serialize(),
-                    LastWrite = DateTime.Now
-                };
+                    Cache = new TokenCacheEntry();
+                }
+
+                Cache.userObjId = userObjId;
+                Cache.cacheBits = this.Serialize();
+                Cache.LastWrite = DateTime.Now;
+
                 //// update the DB and the lastwrite                
-                db.Entry(Cache).State = Cache.TokenCacheEntryID == 0 ? EntityState.Added : EntityState.Modified;                
+                db.Entry(Cache).State = Cache.TokenCacheEntryID == 0 ? EntityState.Added : EntityState.Modified;
                 db.SaveChanges();
                 this.HasStateChanged = false;
             }


### PR DESCRIPTION
…e existing, per-user cache entry.

With this update, if the cache entry already exists for that user, it will be updated instead of duplicated in the database.
